### PR TITLE
feat: add error messages to link/unlink

### DIFF
--- a/src/components/account/account-form.vue
+++ b/src/components/account/account-form.vue
@@ -15,6 +15,10 @@ const props = defineProps({
     type: Object as PropType<Account>,
     required: true,
   },
+  error: {
+    type: String,
+    required: false,
+  },
 });
 const tiki: TikiService | undefined = inject("Tiki");
 const username = ref<HTMLInputElement>();
@@ -36,6 +40,12 @@ watch(
     password.value!.value = newValue?.password ?? "";
     account.value!.value = newValue?.type ?? AccountType.GMAIL;
   },
+);
+
+const errorMessage = ref(props.error);
+watch(
+  () => props.error,
+  (newValue) => (errorMessage.value = newValue),
 );
 </script>
 
@@ -65,6 +75,9 @@ watch(
       required
       @change="update"
     />
+    <div class="error">
+      <p class="error-message" v-if="error">{{ error }}</p>
+    </div>
   </form>
 </template>
 
@@ -119,6 +132,20 @@ input {
   border-radius: 0.5em;
   box-sizing: border-box;
   margin-bottom: 1.2em;
+}
+
+.error {
+  font-family: var(--tiki-font-family);
+  font-size: var(--tiki-font-size);
+  margin: 0 0 2em 0;
+  color: #c73000;
+  text-align: center;
+  font-weight: 500;
+}
+
+.error-message {
+  margin: 0;
+  line-height: 0;
 }
 
 input:focus,

--- a/src/components/account/account-unlink.vue
+++ b/src/components/account/account-unlink.vue
@@ -17,14 +17,26 @@ import { TikiService } from "@/service/tiki-service";
 
 const tiki: TikiService | undefined = inject("Tiki");
 const emits = defineEmits(["back", "close"]);
+const error = ref<string>();
 const form = ref<Account>({
   username: "",
   password: "",
   type: AccountType.GMAIL,
 });
 const submit = async () => {
-  await tiki?.account.logout(form.value);
-  emits("back");
+  if (
+    form.value.username != undefined &&
+    form.value.password != undefined &&
+    form.value.username?.length > 0 &&
+    form.value.password?.length > 0
+  ) {
+    try {
+      await tiki?.account.logout(form.value);
+      emits("back");
+    } catch (err) {
+      error.value = err;
+    }
+  }
 };
 </script>
 

--- a/src/components/buttons/text-button.vue
+++ b/src/components/buttons/text-button.vue
@@ -4,7 +4,8 @@
   -->
 
 <script setup lang="ts">
-defineProps({
+const emit = defineEmits(["click"]);
+const props = defineProps({
   text: {
     type: String,
     required: true,
@@ -19,7 +20,11 @@ defineProps({
 </script>
 
 <template>
-  <button class="textButton" :class="focus ? 'focus' : 'nofocus'">
+  <button
+    class="textButton"
+    :class="focus ? 'focus' : 'nofocus'"
+    @click.stop.prevent="$emit('click')"
+  >
     <component :is="icon" v-if="icon != null" class="icon" />{{ text }}
   </button>
 </template>
@@ -39,6 +44,7 @@ defineProps({
   display: flex;
   align-items: center;
   justify-content: center;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .textButton.focus {


### PR DESCRIPTION
fixes: #20

Also fixes a null pointer bug when trying to submit forms without both a username and password. 

*Note: Displays the raw error message from tiki-receipt-capture-capacitor. We may want to add a more user-friendly text mapping* 