### PR TITLE
fix:Fix the target area of the swipe down

### DIFF
--- a/src/tiki-receipt.vue
+++ b/src/tiki-receipt.vue
@@ -74,7 +74,8 @@ const closeUI = () => {
       (isHeadingElement(element.target.className) ||
         (element.target.className === "body" &&
           (isHeadingElement(element.target.firstElementChild.className) ||
-            isFullScreenElement(element.target.firstElementChild.className))))
+            isFullScreenElement(element.target.firstElementChild.className)))) ||
+            (element.target.className === 'overlay' && element.target.firstElementChild.className === 'bottom-sheet')
     ) {
       state.value = TikiReceiptState.Hidden;
     }


### PR DESCRIPTION
@mike-audi 

Just included the bottom-sheet class in the swipe verification, so the user could close the ui swiping out the pop-out.

Still Following the old design until I improve it.

