### PR TITLE
Fix/refactor the load method

### DIFF
--- a/src/components/account/account-form.vue
+++ b/src/components/account/account-form.vue
@@ -32,11 +32,17 @@ const update = () => {
     ReceiptAccount.fromValue(
       {username: username.value?.value ?? "",
       accountType: {
-        type: account.value?.type,
-        name: account.value?.name,
-        icon: undefined,
-        key: account.value?.key!,
-      },
+         type: "Email",
+         name: account.value?.name!,
+         icon: undefined,
+         key: account.value?.name!,
+       },
+      // accountType: {
+      //   type: account.value?.name!,
+      //   name: account.value?.name!,
+      //   icon: undefined,
+      //   key: account.value?,
+      // },
       password: password.value?.value,}
     ),
   );

--- a/src/components/account/account-form.vue
+++ b/src/components/account/account-form.vue
@@ -5,7 +5,7 @@
 
 <script setup lang="ts">
 import { ReceiptAccount } from "@/service/receipt/receipt-account";
-import { ReceiptAccountType } from "@/service/receipt/receipt-account-type";
+import { AccountTypeCommom } from "@/service/receipt/receipt-account-type";
 import { inject, ref, watch } from "vue";
 import type { PropType } from "vue";
 import { TikiService } from "@/service/tiki-service";
@@ -30,9 +30,14 @@ const update = () => {
   emit(
     "update:account",
     ReceiptAccount.fromValue(
-      username.value?.value ?? "",
-      account.value?.value ?? ReceiptAccountType.GMAIL,
-      password.value?.value,
+      {username: username.value?.value ?? "",
+      accountType: {
+        type: account.value?.type,
+        name: account.value?.name,
+        icon: undefined,
+        key: account.value?.key!,
+      },
+      password: password.value?.value,}
     ),
   );
 };
@@ -42,7 +47,7 @@ watch(
   async (newValue) => {
     username.value!.value = newValue?.username ?? "";
     password.value!.value = newValue?.password ?? "";
-    account.value!.value = newValue?.type ?? ReceiptAccountType.GMAIL;
+    account.value!.value = newValue?.accountType.name ?? "";
   },
 );
 
@@ -58,8 +63,10 @@ watch(
     <label for="accounts">Choose Account</label>
     <select id="accounts" ref="account" required @change="update">
       <option
-        v-for="account in Object.values(ReceiptAccountType)"
+        v-for="account in Object.values(AccountTypeCommom)"
         :value="account"
+        :label="account.name"
+        :selected="account.name"
       >
         {{ account }}
       </option>

--- a/src/components/account/account-item.vue
+++ b/src/components/account/account-item.vue
@@ -20,13 +20,13 @@ defineProps({
 <template>
   <div>
     <div class="account-button" role="button" @click="$emit('click', account)">
-      <img :alt="account.type" :src="account.icon" class="icon" />
+      <img :alt="account.accountType.name" :src="account.accountType.icon?" class="icon" />
       <div
         class="unlink"
-        :class="account.verified ? 'verified' : 'notVerified'"
+        :class="account.isVerified ? 'verified' : 'notVerified'"
       >
         <unlink-icon class="account-item-icon" />
-        {{ account.verified ? "Unlink" : "Error" }}
+        {{ account.isVerified ? "Unlink" : "Error" }}
       </div>
     </div>
     <p class="username">{{ account.username }}</p>

--- a/src/components/account/account-item.vue
+++ b/src/components/account/account-item.vue
@@ -20,11 +20,11 @@ defineProps({
 <template>
   <div>
     <div class="account-button" role="button" @click="$emit('click', account)">
-      <img :alt="account.accountType.name" :src="account.accountType.icon?" class="icon" />
+      <img :alt="account.accountType.name" :src="account.accountType.icon" class="icon" />
       <div
         class="unlink"
         :class="account.isVerified ? 'verified' : 'notVerified'"
-      >
+        >
         <unlink-icon class="account-item-icon" />
         {{ account.isVerified ? "Unlink" : "Error" }}
       </div>

--- a/src/components/account/account-link.vue
+++ b/src/components/account/account-link.vue
@@ -12,7 +12,7 @@ import CircleButton from "@/components/buttons/circle-button.vue";
 import AccountCarousel from "@/components/account/account-carousel.vue";
 import TextButton from "@/components/buttons/text-button.vue";
 import { ReceiptAccount } from "@/service/receipt/receipt-account";
-import { ReceiptAccountType } from "@/service/receipt/receipt-account-type";
+import { AccountTypeCommom } from "@/service/receipt/receipt-account-type";
 import { inject, ref } from "vue";
 import { TikiService } from "@/service/tiki-service";
 
@@ -24,7 +24,7 @@ tiki!.receipt.onAccount("account-link", (acc) => {
 });
 const error = ref<string>();
 const form = ref<ReceiptAccount>(
-  new ReceiptAccount("", ReceiptAccountType.GMAIL, ""),
+  new ReceiptAccount("", AccountTypeCommom.GMAIL, ""),
 );
 const submit = async () => {
   if (
@@ -36,7 +36,7 @@ const submit = async () => {
     try {
       error.value = ''
       await tiki?.receipt.login(form.value);
-      form.value = new ReceiptAccount("", ReceiptAccountType.GMAIL, "");
+      form.value = new ReceiptAccount("", AccountTypeCommom.GMAIL, "");
     } catch (err: any) {
       error.value = err.toString();
     }

--- a/src/components/account/account-unlink.vue
+++ b/src/components/account/account-unlink.vue
@@ -12,14 +12,14 @@ import AccountIconOutline from "@/assets/icons/account-outline.svg?component";
 import TextButton from "@/components/buttons/text-button.vue";
 import { inject, ref } from "vue";
 import { ReceiptAccount } from "@/service/receipt/receipt-account";
-import { ReceiptAccountType } from "@/service/receipt/receipt-account-type";
+import { AccountTypeCommom } from "@/service/receipt/receipt-account-type";
 import { TikiService } from "@/service/tiki-service";
 
 const tiki: TikiService | undefined = inject("Tiki");
 const emits = defineEmits(["back", "close"]);
 const error = ref<string>();
 const form = ref<ReceiptAccount>(
-  new ReceiptAccount("", ReceiptAccountType.GMAIL, ""),
+  new ReceiptAccount("", AccountTypeCommom.GMAIL, ""),
 );
 const submit = async () => {
   if (

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,6 @@ import type {
   Retailer,
   ReceiptCapture,
 } from "@mytiki/tiki-capture-receipt-capacitor";
-import { AccountProvider } from "@mytiki/tiki-capture-receipt-capacitor";
 
 export default {
   /**
@@ -73,7 +72,6 @@ export {
   Tag,
   CommonUsecases,
   CommonTags,
-  AccountProvider,
   ReceiptEvent,
   AccountTypeCommom,
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ import type { SdkService } from "@/service/sdk-service";
 import type { HistoryEvent } from "@/service/history/history-event";
 import { ReceiptEvent } from "@/service/receipt/receipt-event";
 import type { ReceiptAccount } from "@/service/receipt/receipt-account";
-import { ReceiptAccountType } from "@/service/receipt/receipt-account-type";
+import { AccountTypeCommom } from "@/service/receipt/receipt-account-type";
 import { TikiService } from "@/service/tiki-service";
 
 import Vue3TouchEvents from "vue3-touch-events";
@@ -75,7 +75,7 @@ export {
   CommonTags,
   AccountProvider,
   ReceiptEvent,
-  ReceiptAccountType,
+  AccountTypeCommom,
 };
 export type {
   Config,

--- a/src/service/receipt/receipt-account-type.ts
+++ b/src/service/receipt/receipt-account-type.ts
@@ -73,14 +73,19 @@ import { AccountProvider } from "@mytiki/tiki-capture-receipt-capacitor";
 export interface AccountType {
   type: 'Email' | 'Retailer',
   name: string,
-  icon: string
+  icon?: string,
+  key: string
 }
-
 export class AccountTypeCommom{
   /**
    * CME Markets account type 
    */
-  static readonly CME_MARKETS:AccountType =  {type:'Retailer',name:'Acme', icon:AcmeIcon};
+  static readonly CME_MARKETS:AccountType =  {
+    type:'Retailer',
+    name:'Acme',
+    icon:AcmeIcon,
+    key: 'CME_MARKETS'
+  };
   
   /**
    * Albertsons account type.
@@ -89,6 +94,7 @@ export class AccountTypeCommom{
   type: "Retailer",
   icon: AlbertsonsIcon,
   name: "Albertsons",
+  key: 'ALBERTSONS'
 }
   /**
    * Amazon account type.
@@ -97,6 +103,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: AmazonIcon,
     name: "Amazon",
+    key: 'AMAZON'
 }
   /**
    * Amazon Canada account type.
@@ -105,6 +112,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: AmazonIcon,
     name: "Amazon Canada",
+    key: 'AMAZON_CA'
 }
   /**
    * Amazon United Kingdom account type.
@@ -113,6 +121,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: AmazonIcon,
     name: "Amazon United Kingdom",
+    key: 'AMAZON_UK'
 }
   /**
    * AOL account type.
@@ -126,6 +135,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: BedBathAndBeyondIcon,
     name: "Bed Bath & Beyond",
+    key: 'BED_BATH_AND_BEYOND'
 }
   /**
    * Gmail account type.
@@ -133,7 +143,8 @@ export class AccountTypeCommom{
   static readonly GMAIL: AccountType = {
    name: "Gmail",
    type: "Email",
-   icon: GmailIcon
+   icon: GmailIcon,
+   key: 'GMAIL'
   }
 
   /**
@@ -143,6 +154,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: BestBuyIcon,
     name: "Best Buy",
+    key: 'BESTBUY'
 }
   /**
    * BJ’s Wholesale Club account type.
@@ -151,6 +163,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: BJsIcon,
     name: "BJ’s Wholesale Club",
+    key: 'BJS_WHOLESALE'
 }
   /**
    * Chewy account type.
@@ -159,6 +172,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: ChewyIcon,
     name: "Chewy",
+    key: 'CHEWY'
 }
   /**
    * Costco account type.
@@ -167,6 +181,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: CostcoIcon,
     name: "Costco",
+    key: 'COSTCO'
 }
   /**
    * CVS account type.
@@ -175,6 +190,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: CVSIcon,
     name: "CVS",
+    key: 'CVS'
 }
   /**
    * Dick’s Sporting Goods account type.
@@ -183,6 +199,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: DicksIcon,
     name: "Dick’s Sporting Goods",
+    key: 'DICKS_SPORTING_GOODS'
 }
   /**
    * Dollar General account type.
@@ -191,6 +208,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: DollarGeneralIcon,
     name: "Dollar General",
+    key: 'DOLLAR_GENERAL'
 }
   /**
    * DollarTree account type.
@@ -199,6 +217,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: DollarTreeIcon,
     name: "DollarTree",
+    key: 'DOLLAR_TREE'
 }
   /**
    * Domino’s Pizza account type.
@@ -207,6 +226,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: DominosIcon,
     name: "Domino’s Pizza",
+    key: 'DOMINOS_PIZZA'
 }
   /**
    * DoorDash account type.
@@ -215,6 +235,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: DoorDashIcon,
     name: "DoorDash",
+    key: 'DOOR_DASH'
 }
   /**
    * Drizly account type.
@@ -223,6 +244,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: DrizlyIcon,
     name: "Drizly",
+    key: 'DRIZLY'
 }
   /**
    * Family Dollar account type.
@@ -231,6 +253,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: FamilyDollarIcon,
     name: "Family Dollar",
+    key: 'FAMILY_DOLLAR'
   }
     /**
    * Food 4 Less account type.
@@ -239,6 +262,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: Food4LessIcon,
     name: "Food 4 Less",
+    key: 'FOOD_4_LESS'
 }
   /**
    * Food Lion account type.
@@ -247,6 +271,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: FoodLionIcon,
     name: "Food Lion",
+    key: 'FOOD_LION'
 }
   /**
    * Fred Meyer account type.
@@ -255,6 +280,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: FredMeyerIcon,
     name: "Fred Meyer",
+    key: 'FRED_MEYER'
 }
   /**
    * GAP account type.
@@ -263,6 +289,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: GapIcon,
     name: "GAP",
+    key: 'GAP'
 }
   /**
    * Giant Eagle account type.
@@ -271,6 +298,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: GiantEagleIcon,
     name: "Giant Eagle",
+    key: 'GIANT_EAGLE'
 }
   /**
    * Grubhub account type.
@@ -279,6 +307,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: GrubHubIcon,
     name: "Grubhub",
+    key: 'GRUBHUB'
 }
   /**
    * Harris Teeter account type.
@@ -287,6 +316,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: HarrisTeeterIcon,
     name: "Harris Teeter",
+    key: 'HARRIS_TEETER'
 }
   /**
    * H.E.B account type.
@@ -295,6 +325,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: HEBIcon,
     name: "H.E.B",
+    key: 'HEB'
 }
   /**
    * Home Depot account type.
@@ -303,6 +334,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: HomeDepotIcon,
     name: "Home Depot",
+    key: 'HOME_DEPOT'
 }
   /**
    * HyVee account type.
@@ -310,6 +342,7 @@ export class AccountTypeCommom{
   static readonly HYVEE: AccountType = {
     type: "Retailer",
     icon: HyVeeIcon,
+    key: 'HYVEE',
     name: "HyVee",
 }
   /**
@@ -319,6 +352,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: InstacartIcon,
     name: "Instacart",
+    key: 'INSTACART',
 }
   /**
    * Jewel Osco account type.
@@ -327,6 +361,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: JewelOscoIcon,
     name: "Jewel Osco",
+    key: 'JEWEL_OSCO',
 }
   /**
    * Kohl’s account type.
@@ -335,6 +370,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: KohlsIcon,
     name: "Kohl’s",
+    key: 'KOHLS',
 }
   /**
    * Kroger account type.
@@ -343,6 +379,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: KrogerIcon,
     name: "Kroger",
+    key: 'KROGER',
 }
   /**
    * Lowe’s account type.
@@ -351,6 +388,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: LowesIcon,
     name: "Lowe’s",
+    key: 'LOWES',
 }
   /**
    * Macy’s account type.
@@ -359,6 +397,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: MacysIcon,
     name: "Macy’s",
+    key: 'MACYS',
 }
   /**
    * Marshalls account type.
@@ -367,6 +406,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: MarshallsIcon,
     name: "Marshalls",
+    key: 'MARSHALLS',
 }
   /**
    * Meijer account type.
@@ -375,6 +415,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: MeijerIcon,
     name: "Meijer",
+    key: 'MEIJER',
 }
   /**
    * Nike account type.
@@ -382,7 +423,9 @@ export class AccountTypeCommom{
   static readonly NIKE: AccountType = {
     type: "Retailer",
     icon: NikeIcon,
-    name: "Nike",}
+    name: "Nike",
+    key: 'NIKE',
+  }
   /**}
    * Microsoft Outlook account type.
    */
@@ -399,6 +442,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: PublixIcon,
     name: "Publix",
+    key: 'PUBLIX',
 }
   /**
    * Ralphs account type.
@@ -407,6 +451,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: RalphsIcon,
     name: "Ralphs",
+    key: 'RALPHS',
 }
   /**
    * RiteAid account type.
@@ -415,6 +460,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: RiteAidIcon,
     name: "RiteAid",
+    key: 'RITE_AID',
 }
   /**
    * Safeway account type.
@@ -423,6 +469,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: "",
     name: "Safeway",
+    key: 'AFEWAY',
 }
   /**
    * Sam’s Club account type.
@@ -431,6 +478,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: SamsClubIcon,
     name: "Sam’s Club",
+    key: 'SAMS_CLUB',
 }
   /**
    * Seamless account type.
@@ -439,6 +487,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: SeamlessIcon,
     name: "Seamless",
+    key: 'SEAMLESS',
 }
   /**
    * Sephora account type.
@@ -447,6 +496,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: SephoraIcon,
     name: "Sephora",
+    key: 'SEPHORA',
 }
   /**
    * Shipt account type.
@@ -455,6 +505,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: ShiptIcon,
     name: "Shipt",
+    key: 'SHIPT',
 }
   /**
    * ShopRite account type.
@@ -462,7 +513,8 @@ export class AccountTypeCommom{
   static readonly SHOPRITE: AccountType = {
     type: "Retailer",
     icon: ShopRiteIcon,
-    name: "Shoprite"
+    name: "Shoprite",
+    key: 'SHOPRITE',
   }
 
   /**
@@ -472,6 +524,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: SproutsIcon,
     name: "Sprouts",
+    key: 'SPROUTS',
 }
   /**
    * Staples account type.
@@ -480,6 +533,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: StaplesIcon,
     name: "Staples",
+    key: 'STAPLES',
 }
   /**
    * Staples Canada account type.
@@ -488,6 +542,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: StaplesCanadaIcon,
     name: "Staples Canada",
+    key: 'STAPLES_CA',
 }
   /**
    * Starbucks account type.
@@ -496,6 +551,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: StarbucksIcon,
     name: "Starbucks",
+    key: 'STARBUCKS',
 }
   /**
    * Taco Bell account type.
@@ -504,6 +560,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: TacoBellIcon,
     name: "Taco Bell",
+    key: 'TACO_BELL',
 }
   /**
    * Target account type.
@@ -512,6 +569,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: TargetIcon,
     name: "Target",
+    key: 'TARGET',
 }
   /**
    * T.J.Maxx account type.
@@ -520,6 +578,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: TJMaxxIcon,
     name: "T.J.Maxx",
+    key: 'TJ_MAXX',
 }
   /**
    * UberEats account type.
@@ -528,6 +587,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: UberEatsIcon,
     name: "UberEats",
+    key: 'UBER_EATS',
 }
   /**
    * Ulta account type.
@@ -536,6 +596,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: UltaIcon,
     name: "Ulta",
+    key: 'ULTA',
 }
   /**
    * Vons account type.
@@ -543,7 +604,9 @@ export class AccountTypeCommom{
   static readonly VONS: AccountType = {
     type: "Retailer",
     icon: VonsIcon,
-    name: "Vons", }
+    name: "Vons", 
+    key: 'VONS',
+}
   /**}
    * Walgreens account type.
    */
@@ -551,6 +614,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: WalgreensIcon,
     name: "Walgreens",
+    key: 'WALGREENS',
 }
   /**
    * Walmart account type.
@@ -559,6 +623,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: WalmartIcon,
     name: "Walmart",
+    key: 'WALMART',
 }
   /**
    * Walmart Canada account type.
@@ -567,6 +632,7 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: WalmartCanadaIcon,
     name: "Walmart Canada",
+    key: 'WALMART_CA',
 }
   /**
    * Wegman’s account type.
@@ -575,10 +641,13 @@ export class AccountTypeCommom{
     type: "Retailer",
     icon: WegmansIcon,
     name: "Wegman’s",
+    key: 'WEGMANS',
 } 
   // static readonly YAHOO: AccountType = {
   //   type: "Email",
   //   icon: '',
   //   name: "Yahoo",
+  //   key: "YAHOO"
   // }
 }
+

--- a/src/service/receipt/receipt-account-type.ts
+++ b/src/service/receipt/receipt-account-type.ts
@@ -65,38 +65,55 @@ import WalmartIcon from "@/assets/images/walmart.png";
 import WalmartCanadaIcon from "@/assets/images/walmart-canada.png";
 import WegmansIcon from "@/assets/images/wegmans.png";
 //import YahooIcon from "@/assets/images/yahoo.png";
-
 import { AccountProvider } from "@mytiki/tiki-capture-receipt-capacitor";
-
 /**
  * Enumeration of the supported account types.
  */
-export enum ReceiptAccountType {
-  /**
-   * ACME Markets account type.
-   */
-  ACME_MARKETS = "ACME",
 
+export interface AccountType {
+  type: 'Email' | 'Retailer',
+  name: string,
+  icon: string
+}
+
+export class AccountTypeCommom{
+  /**
+   * CME Markets account type 
+   */
+  static readonly CME_MARKETS:AccountType =  {type:'Retailer',name:'Acme', icon:AcmeIcon};
+  
   /**
    * Albertsons account type.
    */
-  ALBERTSONS = "Albertsons",
-
+ static readonly ALBERTSONS: AccountType = {
+  type: "Retailer",
+  icon: AlbertsonsIcon,
+  name: "Albertsons",
+}
   /**
    * Amazon account type.
    */
-  AMAZON = "Amazon",
-
+  static readonly AMAZON: AccountType = {
+    type: "Retailer",
+    icon: AmazonIcon,
+    name: "Amazon",
+}
   /**
    * Amazon Canada account type.
    */
-  AMAZON_CA = "Amazon Canada",
-
+  static readonly AMAZON_CA: AccountType = {
+    type: "Retailer",
+    icon: AmazonIcon,
+    name: "Amazon Canada",
+}
   /**
    * Amazon United Kingdom account type.
    */
-  AMAZON_UK = "Amazon United Kingdom",
-
+  static readonly AMAZON_UK: AccountType = {
+    type: "Retailer",
+    icon: AmazonIcon,
+    name: "Amazon United Kingdom",
+}
   /**
    * AOL account type.
    */
@@ -105,486 +122,463 @@ export enum ReceiptAccountType {
   /**
    * Bed Bath & Beyond account type.
    */
-  BED_BATH_AND_BEYOND = "Bed Bath & Beyond",
-
+  static readonly BED_BATH_AND_BEYOND: AccountType = {
+    type: "Retailer",
+    icon: BedBathAndBeyondIcon,
+    name: "Bed Bath & Beyond",
+}
   /**
    * Gmail account type.
    */
-  GMAIL = "Gmail",
+  static readonly GMAIL: AccountType = {
+   name: "Gmail",
+   type: "Email",
+   icon: GmailIcon
+  }
 
   /**
    * Best Buy account type.
    */
-  BESTBUY = "Best Buy",
-
+  static readonly BESTBUY: AccountType = {
+    type: "Retailer",
+    icon: BestBuyIcon,
+    name: "Best Buy",
+}
   /**
    * BJ’s Wholesale Club account type.
    */
-  BJS_WHOLESALE = "BJ’s Wholesale Club",
-
+  static readonly BJS_WHOLESALE: AccountType = {
+    type: "Retailer",
+    icon: BJsIcon,
+    name: "BJ’s Wholesale Club",
+}
   /**
    * Chewy account type.
    */
-  CHEWY = "Chewy",
-
+  static readonly CHEWY: AccountType = {
+    type: "Retailer",
+    icon: ChewyIcon,
+    name: "Chewy",
+}
   /**
    * Costco account type.
    */
-  COSTCO = "Costco",
-
+  static readonly COSTCO: AccountType = {
+    type: "Retailer",
+    icon: CostcoIcon,
+    name: "Costco",
+}
   /**
    * CVS account type.
    */
-  CVS = "CVS",
-
+  static readonly CVS: AccountType = {
+    type: "Retailer",
+    icon: CVSIcon,
+    name: "CVS",
+}
   /**
    * Dick’s Sporting Goods account type.
    */
-  DICKS_SPORTING_GOODS = "Dick’s Sporting Goods",
-
+  static readonly DICKS_SPORTING_GOODS: AccountType = {
+    type: "Retailer",
+    icon: DicksIcon,
+    name: "Dick’s Sporting Goods",
+}
   /**
    * Dollar General account type.
    */
-  DOLLAR_GENERAL = "Dollar General",
-
+  static readonly DOLLAR_GENERAL: AccountType = {
+    type: "Retailer",
+    icon: DollarGeneralIcon,
+    name: "Dollar General",
+}
   /**
    * DollarTree account type.
    */
-  DOLLAR_TREE = "DollarTree",
-
+  static readonly DOLLAR_TREE: AccountType = {
+    type: "Retailer",
+    icon: DollarTreeIcon,
+    name: "DollarTree",
+}
   /**
    * Domino’s Pizza account type.
    */
-  DOMINOS_PIZZA = "Domino’s Pizza",
-
+  static readonly DOMINOS_PIZZA: AccountType = {
+    type: "Retailer",
+    icon: DominosIcon,
+    name: "Domino’s Pizza",
+}
   /**
    * DoorDash account type.
    */
-  DOOR_DASH = "DoorDash",
-
+  static readonly DOOR_DASH: AccountType = {
+    type: "Retailer",
+    icon: DoorDashIcon,
+    name: "DoorDash",
+}
   /**
    * Drizly account type.
    */
-  DRIZLY = "Drizly",
-
+  static readonly DRIZLY: AccountType = {
+    type: "Retailer",
+    icon: DrizlyIcon,
+    name: "Drizly",
+}
   /**
    * Family Dollar account type.
    */
-  FAMILY_DOLLAR = "Family Dollar",
-  /**
+  static readonly FAMILY_DOLLAR: AccountType = {
+    type: "Retailer",
+    icon: FamilyDollarIcon,
+    name: "Family Dollar",
+  }
+    /**
    * Food 4 Less account type.
    */
-  FOOD_4_LESS = "Food 4 Less",
-
+  static readonly FOOD_4_LESS: AccountType = {
+    type: "Retailer",
+    icon: Food4LessIcon,
+    name: "Food 4 Less",
+}
   /**
    * Food Lion account type.
    */
-  FOOD_LION = "Food Lion",
-
+  static readonly FOOD_LION: AccountType = {
+    type: "Retailer",
+    icon: FoodLionIcon,
+    name: "Food Lion",
+}
   /**
    * Fred Meyer account type.
    */
-  FRED_MEYER = "Fred Meyer",
-
+  static readonly FRED_MEYER: AccountType = {
+    type: "Retailer",
+    icon: FredMeyerIcon,
+    name: "Fred Meyer",
+}
   /**
    * GAP account type.
    */
-  GAP = "GAP",
-
+  static readonly GAP: AccountType = {
+    type: "Retailer",
+    icon: GapIcon,
+    name: "GAP",
+}
   /**
    * Giant Eagle account type.
    */
-  GIANT_EAGLE = "Giant Eagle",
-
+  static readonly GIANT_EAGLE: AccountType = {
+    type: "Retailer",
+    icon: GiantEagleIcon,
+    name: "Giant Eagle",
+}
   /**
    * Grubhub account type.
    */
-  GRUBHUB = "Grubhub",
-
+  static readonly GRUBHUB: AccountType = {
+    type: "Retailer",
+    icon: GrubHubIcon,
+    name: "Grubhub",
+}
   /**
    * Harris Teeter account type.
    */
-  HARRIS_TEETER = "Harris Teeter",
-
+  static readonly HARRIS_TEETER: AccountType = {
+    type: "Retailer",
+    icon: HarrisTeeterIcon,
+    name: "Harris Teeter",
+}
   /**
    * H.E.B account type.
    */
-  HEB = "H.E.B",
-
+  static readonly HEB: AccountType = {
+    type: "Retailer",
+    icon: HEBIcon,
+    name: "H.E.B",
+}
   /**
    * Home Depot account type.
    */
-  HOME_DEPOT = "Home Depot",
-
+  static readonly HOME_DEPOT: AccountType = {
+    type: "Retailer",
+    icon: HomeDepotIcon,
+    name: "Home Depot",
+}
   /**
    * HyVee account type.
    */
-  HYVEE = "HyVee",
-
+  static readonly HYVEE: AccountType = {
+    type: "Retailer",
+    icon: HyVeeIcon,
+    name: "HyVee",
+}
   /**
    * Instacart account type.
    */
-  INSTACART = "Instacart",
-
+  static readonly INSTACART: AccountType = {
+    type: "Retailer",
+    icon: InstacartIcon,
+    name: "Instacart",
+}
   /**
    * Jewel Osco account type.
    */
-  JEWEL_OSCO = "Jewel Osco",
-
+  static readonly JEWEL_OSCO: AccountType = {
+    type: "Retailer",
+    icon: JewelOscoIcon,
+    name: "Jewel Osco",
+}
   /**
    * Kohl’s account type.
    */
-  KOHLS = "Kohl’s",
-
+  static readonly KOHLS: AccountType = {
+    type: "Retailer",
+    icon: KohlsIcon,
+    name: "Kohl’s",
+}
   /**
    * Kroger account type.
    */
-  KROGER = "Kroger",
-
+  static readonly KROGER: AccountType = {
+    type: "Retailer",
+    icon: KrogerIcon,
+    name: "Kroger",
+}
   /**
    * Lowe’s account type.
    */
-  LOWES = "Lowe’s",
-
+  static readonly LOWES: AccountType = {
+    type: "Retailer",
+    icon: LowesIcon,
+    name: "Lowe’s",
+}
   /**
    * Macy’s account type.
    */
-  MACYS = "Macy’s",
-
+  static readonly MACYS: AccountType = {
+    type: "Retailer",
+    icon: MacysIcon,
+    name: "Macy’s",
+}
   /**
    * Marshalls account type.
    */
-  MARSHALLS = "Marshalls",
-
+  static readonly MARSHALLS: AccountType = {
+    type: "Retailer",
+    icon: MarshallsIcon,
+    name: "Marshalls",
+}
   /**
    * Meijer account type.
    */
-  MEIJER = "Meijer",
-
+  static readonly MEIJER: AccountType = {
+    type: "Retailer",
+    icon: MeijerIcon,
+    name: "Meijer",
+}
   /**
    * Nike account type.
    */
-  NIKE = "Nike",
-  /**
+  static readonly NIKE: AccountType = {
+    type: "Retailer",
+    icon: NikeIcon,
+    name: "Nike",}
+  /**}
    * Microsoft Outlook account type.
    */
-  // OUTLOOK = "Outlook",
+  // static readonly OUTLOOK: AccountType =  {
+  //   name:"Outlook",
+  //   type: "Email",
+  //   icon: "",
+  // }
 
   /**
    * Publix account type.
    */
-  PUBLIX = "Publix",
-
+  static readonly PUBLIX: AccountType = {
+    type: "Retailer",
+    icon: PublixIcon,
+    name: "Publix",
+}
   /**
    * Ralphs account type.
    */
-  RALPHS = "Ralphs",
-
+  static readonly RALPHS: AccountType = {
+    type: "Retailer",
+    icon: RalphsIcon,
+    name: "Ralphs",
+}
   /**
    * RiteAid account type.
    */
-  RITE_AID = "RiteAid",
-
+  static readonly RITE_AID: AccountType = {
+    type: "Retailer",
+    icon: RiteAidIcon,
+    name: "RiteAid",
+}
   /**
    * Safeway account type.
    */
-  SAFEWAY = "Safeway",
-
+  static readonly AFEWAY: AccountType = {
+    type: "Retailer",
+    icon: "",
+    name: "Safeway",
+}
   /**
    * Sam’s Club account type.
    */
-  SAMS_CLUB = "Sam’s Club",
-
+  static readonly SAMS_CLUB: AccountType = {
+    type: "Retailer",
+    icon: SamsClubIcon,
+    name: "Sam’s Club",
+}
   /**
    * Seamless account type.
    */
-  SEAMLESS = "Seamless",
-
+  static readonly SEAMLESS: AccountType = {
+    type: "Retailer",
+    icon: SeamlessIcon,
+    name: "Seamless",
+}
   /**
    * Sephora account type.
    */
-  SEPHORA = "Sephora",
-
+  static readonly SEPHORA: AccountType = {
+    type: "Retailer",
+    icon: SephoraIcon,
+    name: "Sephora",
+}
   /**
    * Shipt account type.
    */
-  SHIPT = "Shipt",
-
+  static readonly SHIPT: AccountType = {
+    type: "Retailer",
+    icon: ShiptIcon,
+    name: "Shipt",
+}
   /**
    * ShopRite account type.
    */
-  SHOPRITE = "ShopRite",
+  static readonly SHOPRITE: AccountType = {
+    type: "Retailer",
+    icon: ShopRiteIcon,
+    name: "Shoprite"
+  }
 
   /**
    * Sprouts account type.
    */
-  SPROUTS = "Sprouts",
-
+  static readonly SPROUTS: AccountType = {
+    type: "Retailer",
+    icon: SproutsIcon,
+    name: "Sprouts",
+}
   /**
    * Staples account type.
    */
-  STAPLES = "Staples",
-
+  static readonly STAPLES: AccountType = {
+    type: "Retailer",
+    icon: StaplesIcon,
+    name: "Staples",
+}
   /**
    * Staples Canada account type.
    */
-  STAPLES_CA = "Staples Canada",
-
+  static readonly STAPLES_CA: AccountType = {
+    type: "Retailer",
+    icon: StaplesCanadaIcon,
+    name: "Staples Canada",
+}
   /**
    * Starbucks account type.
    */
-  STARBUCKS = "Starbucks",
-
+  static readonly STARBUCKS: AccountType = {
+    type: "Retailer",
+    icon: StarbucksIcon,
+    name: "Starbucks",
+}
   /**
    * Taco Bell account type.
    */
-  TACO_BELL = "Taco Bell",
-
+  static readonly TACO_BELL: AccountType = {
+    type: "Retailer",
+    icon: TacoBellIcon,
+    name: "Taco Bell",
+}
   /**
    * Target account type.
    */
-  TARGET = "Target",
-
+  static readonly TARGET: AccountType = {
+    type: "Retailer",
+    icon: TargetIcon,
+    name: "Target",
+}
   /**
    * T.J.Maxx account type.
    */
-  TJ_MAXX = "T.J.Maxx",
-
+  static readonly TJ_MAXX: AccountType = {
+    type: "Retailer",
+    icon: TJMaxxIcon,
+    name: "T.J.Maxx",
+}
   /**
    * UberEats account type.
    */
-  UBER_EATS = "UberEats",
-
+  static readonly UBER_EATS: AccountType = {
+    type: "Retailer",
+    icon: UberEatsIcon,
+    name: "UberEats",
+}
   /**
    * Ulta account type.
    */
-  ULTA = "Ulta",
-
+  static readonly ULTA: AccountType = {
+    type: "Retailer",
+    icon: UltaIcon,
+    name: "Ulta",
+}
   /**
    * Vons account type.
    */
-  VONS = "Vons",
-  /**
+  static readonly VONS: AccountType = {
+    type: "Retailer",
+    icon: VonsIcon,
+    name: "Vons", }
+  /**}
    * Walgreens account type.
    */
-  WALGREENS = "Walgreens",
-
+  static readonly WALGREENS: AccountType = {
+    type: "Retailer",
+    icon: WalgreensIcon,
+    name: "Walgreens",
+}
   /**
    * Walmart account type.
    */
-  WALMART = "Walmart",
-
+  static readonly WALMART: AccountType = {
+    type: "Retailer",
+    icon: WalmartIcon,
+    name: "Walmart",
+}
   /**
    * Walmart Canada account type.
    */
-  WALMART_CA = "Walmart Canada",
-
+  static readonly WALMART_CA: AccountType = {
+    type: "Retailer",
+    icon: WalmartCanadaIcon,
+    name: "Walmart Canada",
+}
   /**
    * Wegman’s account type.
    */
-  WEGMANS = "Wegman’s",
-
-  /**
-   * Yahoo account type.
-   */
-  // YAHOO = "Yahoo",
+  static readonly WEGMANS: AccountType = {
+    type: "Retailer",
+    icon: WegmansIcon,
+    name: "Wegman’s",
+} 
+  // static readonly YAHOO: AccountType = {
+  //   type: "Email",
+  //   icon: '',
+  //   name: "Yahoo",
+  // }
 }
-
-/**
- * Reverse string-value mapping of the {@link ReceiptAccountType}. Use to
- * resolve an enum by its string value.
- */
-export const all: Map<string, ReceiptAccountType> = new Map(
-  Object.values(ReceiptAccountType).map(
-    (value) => [`${value}`, value] as const,
-  ),
-);
-
-export const toString = (type: string): string => {
-  return Object.keys(ReceiptAccountType)
-    .find((val) => type.toLowerCase() === val.toLowerCase())!
-    .toLowerCase();
-};
-/**
- * Gets the icon (image src) associated with a {@link ReceiptAccountType}.
- * @param type - The receipt account type.
- * @returns The icon string associated with the receipt account type.
- * @throws Error if the receipt account type is not supported.
- */
-export const icon = (type: ReceiptAccountType): string => {
-  const retailer = Object.values(ReceiptAccountType).find(
-    (retailer) => type.toLowerCase() === retailer.toLowerCase(),
-  );
-  switch (retailer) {
-    case ReceiptAccountType.ACME_MARKETS:
-      return AcmeIcon;
-    case ReceiptAccountType.ALBERTSONS:
-      return AlbertsonsIcon;
-    case ReceiptAccountType.AMAZON:
-      return AmazonIcon;
-    case ReceiptAccountType.AMAZON_CA:
-      return AmazonIcon;
-    case ReceiptAccountType.AMAZON_UK:
-      return AmazonIcon;
-    // case ReceiptAccountType.AOL:
-    //   return AolIcon;
-    case ReceiptAccountType.BED_BATH_AND_BEYOND:
-      return BedBathAndBeyondIcon;
-    case ReceiptAccountType.BESTBUY:
-      return BestBuyIcon;
-    case ReceiptAccountType.BJS_WHOLESALE:
-      return BJsIcon;
-    case ReceiptAccountType.CHEWY:
-      return ChewyIcon;
-    case ReceiptAccountType.COSTCO:
-      return CostcoIcon;
-    case ReceiptAccountType.CVS:
-      return CVSIcon;
-    case ReceiptAccountType.DICKS_SPORTING_GOODS:
-      return DicksIcon;
-    case ReceiptAccountType.DOLLAR_GENERAL:
-      return DollarGeneralIcon;
-    case ReceiptAccountType.DOLLAR_TREE:
-      return DollarTreeIcon;
-    case ReceiptAccountType.DOMINOS_PIZZA:
-      return DominosIcon;
-    case ReceiptAccountType.DOOR_DASH:
-      return DoorDashIcon;
-    case ReceiptAccountType.DRIZLY:
-      return DrizlyIcon;
-    case ReceiptAccountType.FAMILY_DOLLAR:
-      return FamilyDollarIcon;
-    case ReceiptAccountType.FOOD_4_LESS:
-      return Food4LessIcon;
-    case ReceiptAccountType.FOOD_LION:
-      return FoodLionIcon;
-    case ReceiptAccountType.FRED_MEYER:
-      return FredMeyerIcon;
-    case ReceiptAccountType.GAP:
-      return GapIcon;
-    case ReceiptAccountType.GIANT_EAGLE:
-      return GiantEagleIcon;
-    case ReceiptAccountType.GMAIL:
-      return GmailIcon;
-    case ReceiptAccountType.GRUBHUB:
-      return GrubHubIcon;
-    case ReceiptAccountType.HARRIS_TEETER:
-      return HarrisTeeterIcon;
-    case ReceiptAccountType.HEB:
-      return HEBIcon;
-    case ReceiptAccountType.HOME_DEPOT:
-      return HomeDepotIcon;
-    case ReceiptAccountType.HYVEE:
-      return HyVeeIcon;
-    case ReceiptAccountType.INSTACART:
-      return InstacartIcon;
-    case ReceiptAccountType.JEWEL_OSCO:
-      return JewelOscoIcon;
-    case ReceiptAccountType.KOHLS:
-      return KohlsIcon;
-    case ReceiptAccountType.KROGER:
-      return KrogerIcon;
-    case ReceiptAccountType.LOWES:
-      return LowesIcon;
-    case ReceiptAccountType.MACYS:
-      return MacysIcon;
-    case ReceiptAccountType.MARSHALLS:
-      return MarshallsIcon;
-    case ReceiptAccountType.MEIJER:
-      return MeijerIcon;
-    case ReceiptAccountType.NIKE:
-      return NikeIcon;
-    // case ReceiptAccountType.OUTLOOK:
-    //   return OutlookIcon;
-    case ReceiptAccountType.PUBLIX:
-      return PublixIcon;
-    case ReceiptAccountType.RALPHS:
-      return RalphsIcon;
-    case ReceiptAccountType.RITE_AID:
-      return RiteAidIcon;
-    case ReceiptAccountType.SAFEWAY:
-      return SafewayIcon;
-    case ReceiptAccountType.SAMS_CLUB:
-      return SamsClubIcon;
-    case ReceiptAccountType.SEAMLESS:
-      return SeamlessIcon;
-    case ReceiptAccountType.SEPHORA:
-      return SephoraIcon;
-    case ReceiptAccountType.SHIPT:
-      return ShiptIcon;
-    case ReceiptAccountType.SHOPRITE:
-      return ShopRiteIcon;
-    case ReceiptAccountType.SPROUTS:
-      return SproutsIcon;
-    case ReceiptAccountType.STAPLES:
-      return StaplesIcon;
-    case ReceiptAccountType.STAPLES_CA:
-      return StaplesCanadaIcon;
-    case ReceiptAccountType.STARBUCKS:
-      return StarbucksIcon;
-    case ReceiptAccountType.TACO_BELL:
-      return TacoBellIcon;
-    case ReceiptAccountType.TARGET:
-      return TargetIcon;
-    case ReceiptAccountType.TJ_MAXX:
-      return TJMaxxIcon;
-    case ReceiptAccountType.UBER_EATS:
-      return UberEatsIcon;
-    case ReceiptAccountType.ULTA:
-      return UltaIcon;
-    case ReceiptAccountType.VONS:
-      return VonsIcon;
-    case ReceiptAccountType.WALGREENS:
-      return WalgreensIcon;
-    case ReceiptAccountType.WALMART:
-      return WalmartIcon;
-    case ReceiptAccountType.WALMART_CA:
-      return WalmartCanadaIcon;
-    case ReceiptAccountType.WEGMANS:
-      return WegmansIcon;
-    // case ReceiptAccountType.YAHOO:
-    //   return YahooIcon;
-    default:
-      return "";
-    //throw Error("Unsupported ReceiptAccountType");
-  }
-};
-
-/**
- * Converts an email provider to a {@link ReceiptAccountType}.
- * @param provider - The account provider, such as AccountProvider.GMAIL.
- * @returns The corresponding receipt account type, or undefined if not supported.
- */
-export const fromEmailProvider = (
-  provider?: AccountProvider,
-): ReceiptAccountType | undefined => {
-  if (provider === undefined) return undefined;
-  switch (provider) {
-    case AccountProvider.GMAIL:
-      return ReceiptAccountType.GMAIL;
-    // case AccountProvider.AOL:
-    //   return ReceiptAccountType.AOL;
-    // case AccountProvider.YAHOO:
-    //   return ReceiptAccountType.YAHOO;
-    // case AccountProvider.OUTLOOK:
-    //   return ReceiptAccountType.YAHOO;
-    default:
-      return undefined;
-  }
-};
-
-/**
- * Converts a {@link ReceiptAccountType} to an email provider.
- * @param type - The receipt account type.
- * @returns The corresponding email provider, or undefined if not supported.
- */
-export const toEmailProvider = (
-  type: ReceiptAccountType,
-): AccountProvider | undefined => {
-  switch (type) {
-    case ReceiptAccountType.GMAIL:
-      return AccountProvider.GMAIL;
-    default:
-      return undefined;
-  }
-};

--- a/src/service/receipt/receipt-account-type.ts
+++ b/src/service/receipt/receipt-account-type.ts
@@ -65,7 +65,6 @@ import WalmartIcon from "@/assets/images/walmart.png";
 import WalmartCanadaIcon from "@/assets/images/walmart-canada.png";
 import WegmansIcon from "@/assets/images/wegmans.png";
 //import YahooIcon from "@/assets/images/yahoo.png";
-import { AccountProvider } from "@mytiki/tiki-capture-receipt-capacitor";
 /**
  * Enumeration of the supported account types.
  */

--- a/src/service/receipt/receipt-account.ts
+++ b/src/service/receipt/receipt-account.ts
@@ -3,15 +3,8 @@
  * MIT license. See LICENSE file in root directory.
  */
 
-import {
-  toEmailProvider,
-  fromEmailProvider,
-  icon,
-  all,
-} from "./receipt-account-type";
-import { ReceiptAccountType } from "./receipt-account-type";
-import { AccountProvider } from "@mytiki/tiki-capture-receipt-capacitor";
-import type { Account } from "@mytiki/tiki-capture-receipt-capacitor";
+
+import type { AccountType } from "./receipt-account-type";
 
 /**
  * Represents a 3rd-party account used to scrape receipts.
@@ -24,7 +17,7 @@ export class ReceiptAccount {
   /**
    * The 3rd-party account type.
    */
-  type: ReceiptAccountType;
+  accountType: AccountType
   /**
    * The password of the account. Only present during login.
    */
@@ -32,7 +25,7 @@ export class ReceiptAccount {
   /**
    * Indicates whether the account credentials have been verified.
    */
-  verified: boolean;
+  isVerified: boolean;
 
   /**
    * Creates a new ReceiptAccount instance.
@@ -43,83 +36,18 @@ export class ReceiptAccount {
    */
   constructor(
     username: string,
-    type: ReceiptAccountType,
+    accountType: AccountType,
     password?: string,
-    verified?: boolean,
+    isVerified?: boolean,
+
   ) {
     this.username = username;
-    this.type = type;
+    this.accountType = accountType
     this.password = password;
-    this.verified = verified ?? false;
+    this.isVerified = isVerified ?? false;
   }
 
-  /**
-   * Creates a ReceiptAccount instance from a provider, such as Gmail.
-   * @param username - The username of the account.
-   * @param provider - The account provider, such as AccountProvider.GMAIL.
-   * @param password - Optional password of the account.
-   * @param verified - Indicates whether the account credentials have been verified. Default false.
-   * @returns A new ReceiptAccount instance.
-   * @throws Error if the provider is unsupported.
-   */
-  static fromProvider(
-    username: string,
-    provider?: AccountProvider,
-    password?: string,
-    verified?: boolean,
-  ): ReceiptAccount {
-    const type: ReceiptAccountType | undefined = fromEmailProvider(provider);
-    if (type != undefined)
-      return new ReceiptAccount(username, type, password, verified);
-    else throw Error(`Unsupported provider: ${provider}`);
-  }
-
-  /**
-   * Creates a ReceiptAccount instance from a {@link ReceiptAccountType} value.
-   * @param username - The username of the receipt account.
-   * @param value - The string value of the {@link ReceiptAccountType}.
-   * @param password - Optional password of the receipt account.
-   * @param verified - Indicates whether the receipt account is verified. Default false.
-   * @returns A new ReceiptAccount instance.
-   * @throws Error if the value is unsupported.
-   */
-  static fromValue(
-    username: string,
-    value: string,
-    password?: string,
-    verified?: boolean,
-  ): ReceiptAccount {
-    const type: ReceiptAccountType | undefined = all.get(value);
-    if (type != undefined)
-      return new ReceiptAccount(username, type, password, verified);
-    else throw Error(`Unsupported value: ${value}`);
-  }
-
-  /**
-   * Creates a ReceiptAccount instance from a @mytiki/tiki-capture-receipt-capacitor account.
-   * @param account - The account.
-   * @returns A new ReceiptAccount instance.
-   */
-  static fromCapture(account: Account): ReceiptAccount {
-    return ReceiptAccount.fromProvider(
-      account.username,
-      account.provider,
-      undefined,
-      account.verified,
-    );
-  }
-
-  /**
-   * Gets the icon (image src) associated with the account type.
-   */
+  
   get icon(): string {
-    return icon(this.type);
-  }
-
-  /**
-   * Gets the provider associated with the account type.
-   */
-  get provider(): AccountProvider | undefined {
-    return toEmailProvider(this.type);
-  }
-}
+    return this.accountType.icon
+  }}

--- a/src/service/receipt/receipt-account.ts
+++ b/src/service/receipt/receipt-account.ts
@@ -47,7 +47,17 @@ export class ReceiptAccount {
     this.isVerified = isVerified ?? false;
   }
 
+  static fromValue(account): ReceiptAccount {
+    //const type: ReceiptAccountType | undefined = all.get(value);
+    if (account)
+      return new ReceiptAccount(account.username, account.accountType, undefined, account.isVerified);
+    else throw Error(`Unsupported value: ${account}`);
+  }
+ 
   
   get icon(): string {
     return this.accountType.icon!
-  }}
+  }
+
+
+}

--- a/src/service/receipt/receipt-account.ts
+++ b/src/service/receipt/receipt-account.ts
@@ -49,5 +49,5 @@ export class ReceiptAccount {
 
   
   get icon(): string {
-    return this.accountType.icon
+    return this.accountType.icon!
   }}

--- a/src/service/receipt/receipt-account.ts
+++ b/src/service/receipt/receipt-account.ts
@@ -4,6 +4,7 @@
  */
 
 
+import type { Account } from "@mytiki/tiki-capture-receipt-capacitor";
 import type { AccountType } from "./receipt-account-type";
 
 /**
@@ -47,7 +48,7 @@ export class ReceiptAccount {
     this.isVerified = isVerified ?? false;
   }
 
-  static fromValue(account): ReceiptAccount {
+  static fromValue(account: Account): ReceiptAccount {
     //const type: ReceiptAccountType | undefined = all.get(value);
     if (account)
       return new ReceiptAccount(account.username, account.accountType, undefined, account.isVerified);

--- a/src/service/receipt/receipt-service.ts
+++ b/src/service/receipt/receipt-service.ts
@@ -159,12 +159,12 @@ export class ReceiptService {
     const retailAccounts = await this.plugin.retailers();
     retailAccounts.forEach((account) =>
       this.addAccount(
-        account
+        ReceiptAccount.fromValue(account)
       ),
     );
     const emailAccounts = await this.plugin.verifyEmail();
     emailAccounts.forEach((account) =>
-      this.addAccount(account),
+      this.addAccount(ReceiptAccount.fromValue(account)),
     );
   };
 
@@ -205,12 +205,12 @@ export class ReceiptService {
       await this.tiki.sdk.ingest(receipt);
       await this.process(ReceiptEvent.SCAN, {
         receipt: receipt,
-        account: account!,
+        account: ReceiptAccount.fromValue(account!),
       });
       this._onReceiptListeners.forEach((listener) =>
         listener(
           receipt,
-          account!
+          ReceiptAccount.fromValue(account!)
         ),
       );
     } else {

--- a/src/service/receipt/receipt-service.ts
+++ b/src/service/receipt/receipt-service.ts
@@ -10,7 +10,6 @@ import { TikiService } from "@/service/tiki-service";
 import { ReceiptAccount } from "@/service/receipt/receipt-account";
 import { ReceiptEvent } from "@/service/receipt/receipt-event";
 import { HistoryEvent } from "@/service/history/history-event";
-import type { AccountType } from "./receipt-account-type";
 
 /**
  * Service responsible for handling receipt-related operations and events.
@@ -170,17 +169,15 @@ export class ReceiptService {
   /**
    * Load and verify previously logged-in accounts.
    */
-  load = async (): Promise<void> => {
-    const retailAccounts = await this.plugin.retailers();
-    retailAccounts.forEach((account) =>
-      this.addAccount(
-        ReceiptAccount.fromValue(account)
-      ),
-    );
-    const emailAccounts = await this.plugin.verifyEmail();
-    emailAccounts.forEach((account) =>
-      this.addAccount(ReceiptAccount.fromValue(account)),
-    );
+  loadAccounts = async (): Promise<void> => {
+    try {
+      (await this.plugin.accounts()).forEach((account) =>{
+        this.addAccount(ReceiptAccount.fromValue(account))
+      })
+    } catch(error){
+      throw Error (`Could not load the accounts; Error: ${error}`)
+    }
+
   };
 
   private addAccount(account: ReceiptAccount): void {

--- a/src/service/tiki-service.ts
+++ b/src/service/tiki-service.ts
@@ -74,7 +74,7 @@ export class TikiService {
     })
     this._isInitialized = true;
     this.history.load();
-    this.receipt.load();
+    this.receipt.loadAccounts();
     this.receipt.scrape();
     this.receipt.orders();
   }

--- a/src/service/tiki-service.ts
+++ b/src/service/tiki-service.ts
@@ -85,7 +85,7 @@ export class TikiService {
    * @returns A Promise that resolves when the logout is complete.
    */
   async logout(): Promise<void> {
-    await this.receipt.logoutAll();
+    await this.receipt.logout();
     this.history.clear();
   }
 }

--- a/src/service/tiki-service.ts
+++ b/src/service/tiki-service.ts
@@ -69,7 +69,9 @@ export class TikiService {
     await this.receipt.plugin.initialize(
       this.config.key.scanKey,
       this.config.key.intelKey,
-    );
+    ).catch(error=>{
+      throw Error(`Could not initialize; Error: ${error}`)
+    })
     this._isInitialized = true;
     this.history.load();
     this.receipt.load();


### PR DESCRIPTION
Refactor the load method, now it will call just one method from the capture plugin, that methods will return an array of accounts, so its no more necessary split it into a bunch of methods.

Close #98 