### PR TITLE
fix: bug into load accounts

### DIFF
--- a/src/service/receipt/receipt-account.ts
+++ b/src/service/receipt/receipt-account.ts
@@ -6,6 +6,7 @@
 
 import type { Account } from "@mytiki/tiki-capture-receipt-capacitor";
 import type { AccountType } from "./receipt-account-type";
+import { AccountTypeCommom } from "./receipt-account-type";
 
 /**
  * Represents a 3rd-party account used to scrape receipts.
@@ -49,9 +50,17 @@ export class ReceiptAccount {
   }
 
   static fromValue(account: Account): ReceiptAccount {
-    //const type: ReceiptAccountType | undefined = all.get(value);
     if (account)
       return new ReceiptAccount(account.username, account.accountType, account.password, account.isVerified);
+    else throw Error(`Unsupported value: ${account}`);
+  }
+  static fromSource(account: Account): ReceiptAccount {
+    if(account){
+      let accountSource  = Object.values(AccountTypeCommom).find((accountObj) => 
+      accountObj.key === account.source
+      )
+      return new ReceiptAccount(account.username, accountSource, undefined, account.isVerified)
+    }
     else throw Error(`Unsupported value: ${account}`);
   }
 

--- a/src/service/receipt/receipt-service.ts
+++ b/src/service/receipt/receipt-service.ts
@@ -112,9 +112,9 @@ export class ReceiptService {
    */
   async accounts() {
     try {
-      (await this.plugin.accounts()).forEach((account) => {
-        this.addAccount(ReceiptAccount.fromValue(account))
-        this.scan('ONLINE', ReceiptAccount.fromValue(account))
+      (await this.plugin.accounts()).accounts.forEach((account) => {
+        this.addAccount(ReceiptAccount.fromSource(account))
+        this.scan('ONLINE', ReceiptAccount.fromSource(account))
       })
     } catch (error) {
       throw Error(`Could not load the accounts; Error: ${error}`)


### PR DESCRIPTION
fixed a bug in the account method that was not showing the saved accounts in the screen.

indeed was a problem in the forEach parameter and in the fromValue function, so it was necessary to change the function to parse the data from the capture plugin in an account, so I've created a new method for that.